### PR TITLE
Refactor: Standardize persona text directory and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ The digital twin simulation system creates virtual representations of individual
 .
 ├── text_simulation/           # Main simulation code
 │   ├── configs/              # Configuration files
-│   ├── data/                 # Data files
 │   ├── text_personas/        # Persona profile data
 │   ├── text_questions/       # Survey questions
 │   ├── text_simulation_input/ # Combined input files
@@ -58,18 +57,29 @@ poetry install
 
 ## Usage
 
-1. Prepare the data:
-```bash
-poetry run python download_dataset.py
-```
+To run the digital twin simulations, follow these steps:
 
-2. Set the API key for LLMs
-```
-OPENAI_API_KEY=XXXXX
-```
+1.  **Prepare the Data**:
+    First, download the necessary dataset by executing the following command:
+    ```bash
+    poetry run python download_dataset.py
+    ```
 
-3. Run the pipeline scripts
-```bash
-./scripts/run_pipeline.sh --max_personas=5 ## run 5 persona simulation
-./scripts/run_pipeline.sh  ### run all 2058 persona simulation
-```
+2.  **Configure API Access**:
+    Set the `OPENAI_API_KEY` environment variable to enable LLM interactions. Create a file named `.env` in the project's root directory and add your API key as follows:
+    ```
+    OPENAI_API_KEY=your_actual_api_key_here
+    ```
+    *Replace `your_actual_api_key_here` with your valid OpenAI API key.*
+
+3.  **Run the Simulation Pipeline**:
+    Execute the main simulation pipeline using the provided shell scripts. You can run a small test with a limited number of personas or simulate all available personas.
+
+    *   For a small test run (e.g., 5 personas):
+        ```bash
+        ./scripts/run_pipeline.sh --max_personas=5
+        ```
+    *   To run the simulation for all 2058 personas:
+        ```bash
+        ./scripts/run_pipeline.sh
+        ```

--- a/scripts/run_pipeline.sh
+++ b/scripts/run_pipeline.sh
@@ -24,22 +24,18 @@ fi
 # Update the max_personas in the config file
 sed -i '' "s/max_personas: .*/max_personas: $MAX_PERSONAS  # Set to $MAX_PERSONAS for testing/" text_simulation/configs/openai_config.yaml
 
-# Create necessary directories
-mkdir -p text_simulation/data/mega_persona_text
-
 # Run the pipeline steps
 echo "Step 1: Converting personas..."
 poetry run python text_simulation/batch_convert_personas.py \
     --persona_json_dir data/mega_persona_json/mega_persona \
-    --output_text_dir text_simulation/data/mega_persona_text \
+    --output_text_dir text_simulation/text_personas \
     --variant full
 
 echo "Step 2: Converting question JSON to text..."
 poetry run python text_simulation/convert_question_json_to_text.py
 
 echo "Step 3: Creating text simulation input..."
-poetry run python text_simulation/create_text_simulation_input.py \
-    --persona_text_dir text_simulation/data/mega_persona_text
+poetry run python text_simulation/create_text_simulation_input.py 
 
 echo "Step 4: Running LLM simulation..."
 poetry run python text_simulation/run_LLM_simulations.py --config text_simulation/configs/openai_config.yaml --max_personas "$MAX_PERSONAS"


### PR DESCRIPTION
This pull request introduces several improvements to enhance the clarity and consistency of the digital twin simulation project.

**Key Changes:**

*   **Standardized Persona Text Directory:**
    *   The `run_pipeline.sh` script has been updated to consistently use `text_simulation/text_personas` as the output directory for processed persona text files.
    *   The previous, potentially confusing, path `text_simulation/data/mega_persona_text` has been removed, along with the command that created this directory. This simplifies the data flow for persona processing.

*   **README.md Enhancements:**
    *   The "Project Structure" section in the `README.md` has been updated to accurately reflect the current directory layout, removing the erroneous `data/` subdirectory under `text_simulation/`.
    *   The "Usage" section has been significantly revised to provide clearer, more professional, and step-by-step instructions for:
        *   Preparing the dataset.
        *   Configuring the `OPENAI_API_KEY`.
        *   Running the simulation pipeline, with distinct examples for partial and full runs.

**Motivation:**

These changes aim to:
*   Improve the maintainability and understandability of the simulation pipeline by using a consistent directory structure.
*   Enhance the user experience by providing clearer and more accurate documentation in the `README.md`.

This should provide a good overview for anyone reviewing the pull request. Let me know if you'd like any modifications!
